### PR TITLE
Add swagger endpoint with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ go run ./cmd/server
 go run ./cmd/cli
 ```
 
-The server exposes three endpoints:
+The server exposes four endpoints:
 
 - `POST /transaction` – add a new transaction block using JSON payload `{"from":"Alice","to":"Bob","amount":5}`.
 - `GET /chain` – retrieve the full chain.
 - `GET /validate` – verify the chain integrity.
+- `GET /swagger.json` – retrieve an OpenAPI specification for the API.
 
 Example usage with `curl`:
 
@@ -32,6 +33,7 @@ curl -X POST -d '{"from":"Alice","to":"Bob","amount":5}' \
   -H 'Content-Type: application/json' http://localhost:8080/transaction
 curl http://localhost:8080/chain
 curl http://localhost:8080/validate
+curl http://localhost:8080/swagger.json
 ```
 
 ## Package layout

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,38 @@ import (
 	"blockchain_go/internal/blockchain"
 )
 
+// swaggerSpec is a minimal OpenAPI definition describing the HTTP endpoints
+// provided by the server. It is served at /swagger.json.
+const swaggerSpec = `{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Blockchain API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/transaction": {
+      "post": {
+        "summary": "Add transaction",
+        "responses": {
+          "201": {"description": "created"}
+        }
+      }
+    },
+    "/chain": {
+      "get": {
+        "summary": "Get blockchain",
+        "responses": {"200": {"description": "chain"}}
+      }
+    },
+    "/validate": {
+      "get": {
+        "summary": "Validate chain",
+        "responses": {"200": {"description": "status"}}
+      }
+    }
+  }
+}`
+
 // Server exposes HTTP handlers to interact with the blockchain.
 
 type Server struct {
@@ -63,12 +95,19 @@ func (s *Server) validate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// serveSwagger writes the OpenAPI specification used to document the API.
+func (s *Server) serveSwagger(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(swaggerSpec))
+}
+
 func main() {
 	srv := NewServer(2)
 
 	http.HandleFunc("/transaction", srv.addTransaction)
 	http.HandleFunc("/chain", srv.getChain)
 	http.HandleFunc("/validate", srv.validate)
+	http.HandleFunc("/swagger.json", srv.serveSwagger)
 
 	log.Println("Server listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -14,6 +14,7 @@ func TestServerEndpoints(t *testing.T) {
 	mux.HandleFunc("/transaction", srv.addTransaction)
 	mux.HandleFunc("/chain", srv.getChain)
 	mux.HandleFunc("/validate", srv.validate)
+	mux.HandleFunc("/swagger.json", srv.serveSwagger)
 
 	// Add a transaction
 	tx := map[string]interface{}{"from": "A", "to": "B", "amount": 1.0}
@@ -39,5 +40,16 @@ func TestServerEndpoints(t *testing.T) {
 	mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Fetch swagger spec
+	req = httptest.NewRequest(http.MethodGet, "/swagger.json", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("openapi")) {
+		t.Fatal("swagger spec missing 'openapi' key")
 	}
 }


### PR DESCRIPTION
## Summary
- serve a minimal OpenAPI spec from `/swagger.json`
- test the new swagger endpoint
- document swagger support in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d3823558c832f9d5037a322efdb15