### PR TITLE
Fix block table sort toggle

### DIFF
--- a/webui/src/components/BlockTable.jsx
+++ b/webui/src/components/BlockTable.jsx
@@ -26,7 +26,11 @@ export default function BlockTable({ chain, showControls = true }) {
     const arr = [...filtered];
     const dir = order === 'asc' ? 1 : -1;
     arr.sort((a, b) => {
-      if (orderBy === 'timestamp') return dir * (a.Timestamp - b.Timestamp);
+      if (orderBy === 'timestamp') {
+        const at = new Date(a.Timestamp).getTime();
+        const bt = new Date(b.Timestamp).getTime();
+        return dir * (at - bt);
+      }
       return dir * (a.index - b.index);
     });
     return arr;


### PR DESCRIPTION
## Summary
- parse timestamp strings when sorting blocks in the UI

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e2fed1728832fb15494f119964b01